### PR TITLE
[MMP-26839] Update MMP back office order details URL

### DIFF
--- a/app/code/community/MiraklSeller/Core/Helper/Connection.php
+++ b/app/code/community/MiraklSeller/Core/Helper/Connection.php
@@ -28,7 +28,7 @@ class MiraklSeller_Core_Helper_Connection extends Mage_Core_Helper_Data
     public function getMiraklOrderUrl(Connection $connection, MiraklOrder $miraklOrder)
     {
         $url = sprintf(
-            '%s/mmp/shop/order/%s/information',
+            '%s/mmp/shop/order/%s',
             $connection->getBaseUrl(),
             $miraklOrder->getId()
         );


### PR DESCRIPTION
In MMP, back office order details URL is now `/mmp/(shop|operator)/order/{orderUuid}`. This URL ending with `/information` is deprecated and will be deleted soon (`/mmp/(shop|operator)/order/{orderUuid}/information`).